### PR TITLE
change php requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "~5.6|~7.0|~8.0",
+        "php": ">=7.4",
         "hidehalo/nanoid-php": "1.1.8",
         "ext-json": "*"
     },


### PR DESCRIPTION
Ao usar a biblioteca na classe SerialNumber na linha 13 `private array $config=[];` esse tipo de declaração só é aceita no php 7.4 ou maior.